### PR TITLE
Remove unanchored git dependency, update to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "base-env",
   "description": "Base plugin, creates a normalized environment object from a function, filepath or instance of base.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "homepage": "https://github.com/node-base/base-env",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "repository": "node-base/base-env",
@@ -34,7 +34,7 @@
     "kind-of": "^3.0.3",
     "lazy-cache": "^2.0.1",
     "os-homedir": "^1.0.1",
-    "resolve-file": "github:jonschlinkert/resolve-file"
+    "resolve-file": "^0.3.0"
   },
   "devDependencies": {
     "base": "^0.9.0",


### PR DESCRIPTION
The 0.3.0 version is [published to npm](https://www.npmjs.com/package/base-env/v/0.3.0) and used by [some other projects](https://www.npmjs.com/package/base-generators). Its git dependency on `resolve-file`, without a reference specified, causes thrash in npm `package-lock.json` files when `npm install` is run multiple times, as npm resolves the reference differently on different runs.

Switching to what seems to be the intent (referencing a [published version of `resolve-file`](https://www.npmjs.com/package/resolve-file/v/0.3.0)) resolves this because `npm` knows how to handle packages from `npm` much better than those from a git repo.

The version of `base-env` is bumped to reflect this change.

Hopefully this too can be published to `npm` 🙂 